### PR TITLE
fix typo in package doc

### DIFF
--- a/package.go
+++ b/package.go
@@ -1,6 +1,6 @@
 // Package winfsp is the native binding API for WinFSP.
 //
-// It's API definition conforms to the descriptions in
+// Its API definition conforms to the descriptions in
 // https://github.com/winfsp/winfsp/wiki/WinFsp-API-winfsp.h,
 // while we invoke the API in a DLLProc+NonCGO manner.
 //


### PR DESCRIPTION
"Its" (possessive), not "it's" (contraction of "it is")