### PR TITLE
fix Debug option to also ignore non-nil error Errno(0)

### DIFF
--- a/host_windows.go
+++ b/host_windows.go
@@ -2041,6 +2041,9 @@ func Mount(
 			uintptr(unsafe.Pointer(result.fileSystem)),
 			uintptr(math.MaxUint32),
 		)
+		if err == syscall.Errno(0) {
+			err = nil
+		}
 		if err != nil {
 			return nil, errors.Wrap(err, "FspFileSystemSetDebugLogF")
 		}


### PR DESCRIPTION
Without this, the Debug option never worked, always failing with
a "the operation completed successfully" message.

This is a minimal fix. I'll send out a larger and more invasive fix
next, to reduce all the repetition around syscall.Proc.Call's
non-conventional API.
