### PR TITLE
rename-go-module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/aegistudio/go-winfsp
+module github.com/winfsp/go-winfsp
 
 go 1.23
 

--- a/gofs/gofs_windows.go
+++ b/gofs/gofs_windows.go
@@ -12,10 +12,10 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/sys/windows"
 
-	"github.com/aegistudio/go-winfsp"
-	"github.com/aegistudio/go-winfsp/filetime"
-	"github.com/aegistudio/go-winfsp/pathlock"
-	"github.com/aegistudio/go-winfsp/procsd"
+	"github.com/winfsp/go-winfsp"
+	"github.com/winfsp/go-winfsp/filetime"
+	"github.com/winfsp/go-winfsp/pathlock"
+	"github.com/winfsp/go-winfsp/procsd"
 )
 
 type File interface {

--- a/winfsp_test.go
+++ b/winfsp_test.go
@@ -13,8 +13,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aegistudio/go-winfsp"
-	"github.com/aegistudio/go-winfsp/gofs"
+	"github.com/winfsp/go-winfsp"
+	"github.com/winfsp/go-winfsp/gofs"
 )
 
 func TestMount(t *testing.T) {


### PR DESCRIPTION
Rename to go module name to "github.com/winfsp/go-winfsp".