### PR TITLE
case-insensitive-filesystem & file-id

### DIFF
--- a/examples/memfs/cmd/main.go
+++ b/examples/memfs/cmd/main.go
@@ -48,8 +48,8 @@ func init() {
 		&mountpoint, "mount", "m", mountpoint,
 		"Where to mount the directory",
 	)
-	rootCmd.PersistentFlags().BoolVar(
-		&caseInsensitive, "case-insensitive", caseInsensitive,
+	rootCmd.PersistentFlags().BoolVarP(
+		&caseInsensitive, "case-insensitive", "i", caseInsensitive,
 		"Whether the filesystem is case insensitive",
 	)
 }

--- a/examples/memfs/cmd/main.go
+++ b/examples/memfs/cmd/main.go
@@ -15,7 +15,8 @@ import (
 )
 
 var (
-	mountpoint string = "X:"
+	mountpoint      string = "X:"
+	caseInsensitive bool   = false
 )
 
 var rootCmd = &cobra.Command{
@@ -24,8 +25,10 @@ var rootCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Create and mount the filesystem.
 		ptfs, err := winfsp.Mount(
-			gofs.New(memfs.New()), mountpoint,
-			winfsp.CaseSensitive(true),
+			gofs.New(memfs.New(
+				memfs.WithCaseInsensitive(caseInsensitive),
+			)),
+			mountpoint,
 		)
 		if err != nil {
 			return errors.Wrap(err, "mount filesystem")
@@ -44,6 +47,10 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(
 		&mountpoint, "mount", "m", mountpoint,
 		"Where to mount the directory",
+	)
+	rootCmd.PersistentFlags().BoolVar(
+		&caseInsensitive, "case-insensitive", caseInsensitive,
+		"Whether the filesystem is case insensitive",
 	)
 }
 

--- a/filesystem_windows.go
+++ b/filesystem_windows.go
@@ -1566,6 +1566,16 @@ func Options(opts ...Option) Option {
 	}
 }
 
+// BehaviourDefaultOptions allows the implementors
+// of BehaviourBase to specify a set of default
+// winfsp.Options with respect to their own state.
+//
+// The user may still override the options, but
+// at their own risks.
+type BehaviourDefaultOptions interface {
+	DefaultOptions() []Option
+}
+
 const (
 	fspNetDeviceName  = "WinFSP.Net"
 	fspDiskDeviceName = "WinFSP.Disk"
@@ -1601,6 +1611,9 @@ func Mount(
 		return nil, err
 	}
 	option := newOption()
+	if inner, ok := fs.(BehaviourDefaultOptions); ok {
+		Options(inner.DefaultOptions()...)(option)
+	}
 	Options(opts...)(option)
 	created := false
 

--- a/gofs/package.go
+++ b/gofs/package.go
@@ -10,6 +10,14 @@
 // On the filesystem level, it supports Stat, OpenFile,
 // Mkdir, Remove and Rename operations.
 //
+// The filesystem can be either case-sensitive or
+// case-insensitive. By default, it's case-sensitive.
+// It can be switched to case-insensitive by specifying
+// `gofs.WithCaseInsensitive(true)`. When it is
+// case-insensitive, the implementor must support
+// opening file with ignored cases, while preserving
+// the cases when the file was created.
+//
 // This makes it works even if the underlying file system
 // is backed by a Window's native directory through the
 // language interfaces by Golang.


### PR DESCRIPTION
- Add support for case-insensitive `gofs` filesystems. This will affect how `gofs` recognizes paths, in either case-sensitive or case-insensitive manner. E.g., `A/B/C` and `a/b/c` are thought to be the same path if it was case-insensitive.
- Add support for File ID, by letting the implementor of `gofs.FileSystem` to provide a `os.FileInfo` that implements `gofs.FileInfoFileID`. This is useful when the filesystem is able to assign a fixed File ID on the disk, so that they can identify file nodes by IDs.