### PR TITLE
fix(winfsp): free the SID allocated by FspPosixMapUidToSid.

### DIFF
--- a/helper_windows.go
+++ b/helper_windows.go
@@ -79,6 +79,12 @@ func init() {
 	registerProc("FspPosixMapUidToSid", &posixMapUidToSid)
 }
 
+var deleteSid dllProc
+
+func init() {
+	registerProc("FspDeleteSid", &deleteSid)
+}
+
 // PosixMapUidToSid maps a POSIX UID to a Windows SID.
 //
 // Will load WinFSP DLL if it has not been loaded, and **panic** if it
@@ -94,7 +100,19 @@ func PosixMapUidToSid(uid uint32) (*windows.SID, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "FspPosixMapUidToSid")
 	}
-	return sid, nil
+
+	// The SID is owned by WinFSP's allocator, so it can't just be returned (it
+	// would leak) nor freed with LocalFree/GC.
+	defer func() {
+		deleteSid.Call(
+			uintptr(unsafe.Pointer(sid)),
+			posixMapUidToSid.proc.Addr(),
+		)
+		runtime.KeepAlive(sid)
+	}()
+
+	// Return a Go-managed copy.
+	return sid.Copy()
 }
 
 var setSecurityDescriptor dllProc


### PR DESCRIPTION
The SID is allocated with WinFSP's own allocator and was returned to the caller without ever being freed. Return a Go-managed copy and release the original with FspDeleteSid.

Another approach would be to make the caller responsible for freeing by making a function specifically for freeing the result of this function. I thought this was cleaner but happy to do that instead if you prefer.
